### PR TITLE
esp_rmaker_core: Add event for MQTT connection (MEGH-1066)

### DIFF
--- a/components/esp_rmaker_core/include/esp_rmaker_core.h
+++ b/components/esp_rmaker_core/include/esp_rmaker_core.h
@@ -34,6 +34,8 @@ typedef enum {
     RMAKER_EVENT_CLAIM_SUCCESSFUL,
     /** Self Claiming Failed */
     RMAKER_EVENT_CLAIM_FAILED,
+    /** MQTT Is Connected */
+    RMAKER_EVENT_MQTT_CONNECTED,
 } esp_rmaker_event_t;
 
 /** ESP RainMaker Node information */

--- a/components/esp_rmaker_core/src/esp_rmaker_core.c
+++ b/components/esp_rmaker_core/src/esp_rmaker_core.c
@@ -780,6 +780,7 @@ static void esp_rmaker_task(void *param)
         vTaskDelete(NULL);
     }
     g_ra_handle->mqtt_connected = true;
+    esp_rmaker_post_event(RMAKER_EVENT_MQTT_CONNECTED, NULL, 0);
     if (esp_rmaker_report_node_config_and_state() != ESP_OK) {
         ESP_LOGE(TAG, "Aborting!!!");
         goto rmaker_end;

--- a/examples/switch/main/app_main.c
+++ b/examples/switch/main/app_main.c
@@ -56,6 +56,9 @@ static void event_handler(void* arg, esp_event_base_t event_base,
             case RMAKER_EVENT_CLAIM_FAILED:
                 ESP_LOGI(TAG, "RainMaker Claim Failed.");
                 break;
+            case RMAKER_EVENT_MQTT_CONNECTED:
+                ESP_LOGI(TAG, "RainMaker Connected to MQTT.");
+                break;
             default:
                 ESP_LOGW(TAG, "Unhandled RainMaker Event: %d", event_id);
         }


### PR DESCRIPTION
Adds an event for when MQTT connects from the rmaker task.

This can be useful in the case of changing power modes or similar only after the MQTT server has successfully connected.