### PR TITLE
Don't delete work queue task when local_ctrl fails to start (MEGH-1977)

### DIFF
--- a/components/esp_rainmaker/src/core/esp_rmaker_core.c
+++ b/components/esp_rainmaker/src/core/esp_rmaker_core.c
@@ -282,7 +282,7 @@ static void esp_rmaker_task(void *data)
 #ifdef CONFIG_ESP_RMAKER_LOCAL_CTRL_ENABLE
     if (esp_rmaker_start_local_ctrl_service(esp_rmaker_get_node_id()) != ESP_OK) {
         ESP_LOGE(TAG, "Failed to start local control service. Aborting!!!");
-        vTaskDelete(NULL);
+        goto rmaker_err;
     }
 #endif /* CONFIG_ESP_RMAKER_LOCAL_CTRL_ENABLE */
     err = esp_rmaker_mqtt_connect();


### PR DESCRIPTION
This vTaskDelete statement was probably missed when the work queue has been restructured and extracted in a separate component.

See commit: 31d4b375e35831ac93026bb225e1252b9271361a