### PR TITLE
unknown type name 'time_t'' error in esp_schedule_nvs.c (MEGH-5093)

### DIFF
--- a/components/esp_schedule/src/esp_schedule_nvs.c
+++ b/components/esp_schedule/src/esp_schedule_nvs.c
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <string.h>
+#include <time.h>
 #include <esp_log.h>
 #include <nvs.h>
 #include "esp_schedule_internal.h"


### PR DESCRIPTION
Added #include <time.h> to resolve compilation error in esp_schedule_nvs.c when using ESP-IDF v5.3-dev-277-gc8243465e4. The error was caused by the unknown type name 'time_t', and this inclusion ensures that the necessary type is recognized during compilation.