### PR TITLE
avoid GCC -O2 warning stringop-truncation (MEGH-5205)

### DIFF
--- a/components/esp_rainmaker/src/core/esp_rmaker_scenes.c
+++ b/components/esp_rainmaker/src/core/esp_rmaker_scenes.c
@@ -216,11 +216,12 @@ static esp_err_t esp_rmaker_scenes_parse_info_and_flags(jparse_ctx_t *jctx, char
             *info = NULL;
         }
 
-        if (strlen(_info) > 0) {
+        int len = strlen(_info);
+        if (len > 0) {
             /* +1 for NULL termination */
-            *info = (char *)MEM_CALLOC_EXTRAM(1, strlen(_info) + 1);
+            *info = (char *)MEM_CALLOC_EXTRAM(1, len + 1);
             if (*info) {
-                strncpy(*info, _info, strlen(_info));
+                memcpy(*info, _info, len + 1);
             }
         }
     }

--- a/components/esp_rainmaker/src/core/esp_rmaker_schedule.c
+++ b/components/esp_rainmaker/src/core/esp_rmaker_schedule.c
@@ -628,11 +628,12 @@ static esp_err_t esp_rmaker_schedule_parse_info_and_flags(jparse_ctx_t *jctx, ch
             *info = NULL;
         }
 
-        if (strlen(_info) > 0) {
+        int len = strlen(_info);
+        if (len > 0) {
             /* +1 for NULL termination */
-            *info = (char *)MEM_CALLOC_EXTRAM(1, strlen(_info) + 1);
+            *info = (char *)MEM_CALLOC_EXTRAM(1, len + 1);
             if (*info) {
-                strncpy(*info, _info, strlen(_info));
+                memcpy(*info, _info, len + 1);
             }
         }
     }


### PR DESCRIPTION
This fixes warning/error:

error: 'strncpy' output truncated before terminating nul copying as many bytes from a string as its length [-Werror=stringop-truncation]
  635 |                 strncpy(*info, _info, strlen(_info));