### PR TITLE
Use memcpy instead of strncpy to silence compiler warning (MEGH-5483)

### DIFF
--- a/components/esp_rainmaker/src/core/esp_rmaker_scenes.c
+++ b/components/esp_rainmaker/src/core/esp_rmaker_scenes.c
@@ -220,7 +220,7 @@ static esp_err_t esp_rmaker_scenes_parse_info_and_flags(jparse_ctx_t *jctx, char
             /* +1 for NULL termination */
             *info = (char *)MEM_CALLOC_EXTRAM(1, strlen(_info) + 1);
             if (*info) {
-                strncpy(*info, _info, strlen(_info));
+                memcpy(*info, _info, strlen(_info));
             }
         }
     }

--- a/components/esp_rainmaker/src/core/esp_rmaker_schedule.c
+++ b/components/esp_rainmaker/src/core/esp_rmaker_schedule.c
@@ -632,7 +632,7 @@ static esp_err_t esp_rmaker_schedule_parse_info_and_flags(jparse_ctx_t *jctx, ch
             /* +1 for NULL termination */
             *info = (char *)MEM_CALLOC_EXTRAM(1, strlen(_info) + 1);
             if (*info) {
-                strncpy(*info, _info, strlen(_info));
+                memcpy(*info, _info, strlen(_info));
             }
         }
     }


### PR DESCRIPTION
The old version triggers a `stringop-truncation` compiler warning. According to the [GCC manual](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wstringop-truncation), `memcpy` is the suggested fix in this exact scenario.

Curious: the warning seems to be only triggered in esp-idf's `CONFIG_COMPILER_OPTIMIZATION_PERF` mode (which corresponds to GCC's `-O2` flag). It seems that GCC triggers the warning for `-O2`, but not for `-O1` ([demo](https://gcc.godbolt.org/z/cPTb44GEj)).