### PR TITLE
Fixed compile error on Zigbee gateway example by updated dependencies… (MEGH-6454) #347 (MEGH-6455)

### DIFF
--- a/examples/zigbee_gateway/main/esp_gateway_main.c
+++ b/examples/zigbee_gateway/main/esp_gateway_main.c
@@ -124,7 +124,6 @@ void esp_zb_app_signal_handler(esp_zb_app_signal_t *signal_struct)
     esp_err_t err_status = signal_struct->esp_err_status;
     esp_zb_app_signal_type_t sig_type = *p_sg_p;
     esp_zb_zdo_signal_device_annce_params_t *dev_annce_params = NULL;
-    esp_zb_zdo_signal_macsplit_dev_boot_params_t *rcp_version = NULL;
 
     switch (sig_type) {
     case ESP_ZB_ZDO_SIGNAL_SKIP_STARTUP:
@@ -132,11 +131,6 @@ void esp_zb_app_signal_handler(esp_zb_app_signal_t *signal_struct)
         esp_app_rainmaker_main(); // rainmaker task
 
         esp_zb_bdb_start_top_level_commissioning(ESP_ZB_BDB_MODE_INITIALIZATION);
-        break;
-    case ESP_ZB_MACSPLIT_DEVICE_BOOT:
-        ESP_LOGI(TAG, "Zigbee rcp device booted");
-        rcp_version = (esp_zb_zdo_signal_macsplit_dev_boot_params_t *)esp_zb_app_signal_get_params(p_sg_p);
-        ESP_LOGI(TAG, "Running RCP Version:%s", rcp_version->version_str);
         break;
     case ESP_ZB_BDB_SIGNAL_DEVICE_FIRST_START:
     case ESP_ZB_BDB_SIGNAL_DEVICE_REBOOT:

--- a/examples/zigbee_gateway/main/idf_component.yml
+++ b/examples/zigbee_gateway/main/idf_component.yml
@@ -1,8 +1,8 @@
 ## IDF Component Manager Manifest File
 dependencies:
-  espressif/esp-zboss-lib: "~1.3.0"
-  espressif/esp-zigbee-lib: "~1.3.0"
-  espressif/esp_rcp_update: "~0.3.0"
+  espressif/esp-zboss-lib: "~1.6.0"
+  espressif/esp-zigbee-lib: "~1.6.0"
+  espressif/esp_rcp_update: "~1.2.0"
   espressif/esp-serial-flasher: "~0.0.4"
   ## Required IDF version
   idf:


### PR DESCRIPTION
… version.

<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

Veirfied esp-zigbee-sdk on Zigbee gateway example works on development kit ESP Thread Border Router / Zigbee Gateway V1.2. So compare code from esp-rainmaker with esp-zigbee-sdk then modified `examples/zigbee_gateway/main/idf_component.yml`.

But then try to build and it have new issue with below build  error. So according to new build error, modified code on `examples/zigbee_gateway/main/esp_gateway_main.c` according to esp-zigbee-sdk code of `esp-zigbee-sdk/examples/esp_zigbee_gateway/main/esp_zigbee_gateway.c`

Finally it can be successfully build and successfully add Zigbee gateway to Rainmaker mobile app.

```
Executing action: all (aliases: build)
Running ninja in directory /home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/build
Executing "ninja all"...
[1/1] cd /home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/build/bootloader/esp-idf/esptool_py && /home/henry/esp/v5.4/.espressif/python_env/idf.../partition_table/check_sizes.py --offset 0x8000 bootloader 0x0 /home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/build/bootloader/bootloader.bin
Bootloader binary size 0x5260 bytes. 0x2da0 bytes (36%) free.
[4/9] Building C object esp-idf/main/CMakeFiles/__idf_main.dir/esp_gateway_main.c.obj
FAILED: esp-idf/main/CMakeFiles/__idf_main.dir/esp_gateway_main.c.obj 
ccache /home/henry/esp/v5.4/.espressif/tools/xtensa-esp-elf/esp-14.2.0_20241119/xtensa-esp-elf/bin/xtensa-esp32s3-elf-gcc -DESP_MDNS_VERSION_NUMBER=\"1.8.0\" -DESP_PLATFORM -DIDF_VER=\"v5.4\" -DMBEDTLS_CONFIG_FILE=\"mbedtls/esp_config.h\" -DMD5_ENABLED=1 -DOPENTHREAD_CONFIG_FILE=\"openthread-core-esp32x-spinel-config.h\" -DOPENTHREAD_PROJECT_LIB_CONFIG_FILE=\"openthread-core-esp32x-spinel-config.h\" -DSERIAL_FLASHER_BOOT_HOLD_TIME_MS=50 -DSERIAL_FLASHER_RESET_HOLD_TIME_MS=100 -DSOC_MMU_PAGE_SIZE=CONFIG_MMU_PAGE_SIZE -DSOC_XTAL_FREQ_MHZ=CONFIG_XTAL_FREQ -DUNITY_INCLUDE_CONFIG_H -D_GLIBCXX_HAVE_POSIX_SEMAPHORE -D_GLIBCXX_USE_POSIX_SEMAPHORE -D_GNU_SOURCE -D_POSIX_READER_WRITER_LOCKS -I/home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/build/config -I/home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/main -I/home/henry/esp/v5.4/esp-idf/components/newlib/platform_include -I/home/henry/esp/v5.4/esp-idf/components/freertos/config/include -I/home/henry/esp/v5.4/esp-idf/components/freertos/config/include/freertos -I/home/henry/esp/v5.4/esp-idf/components/freertos/config/xtensa/include -I/home/henry/esp/v5.4/esp-idf/components/freertos/FreeRTOS-Kernel/include -I/home/henry/esp/v5.4/esp-idf/components/freertos/FreeRTOS-Kernel/portable/xtensa/include -I/home/henry/esp/v5.4/esp-idf/components/freertos/FreeRTOS-Kernel/portable/xtensa/include/freertos -I/home/henry/esp/v5.4/esp-idf/components/freertos/esp_additions/include -I/home/henry/esp/v5.4/esp-idf/components/esp_hw_support/include -I/home/henry/esp/v5.4/esp-idf/components/esp_hw_support/include/soc -I/home/henry/esp/v5.4/esp-idf/components/esp_hw_support/include/soc/esp32s3 -I/home/henry/esp/v5.4/esp-idf/components/esp_hw_support/dma/include -I/home/henry/esp/v5.4/esp-idf/components/esp_hw_support/ldo/include -I/home/henry/esp/v5.4/esp-idf/components/esp_hw_support/debug_probe/include -I/home/henry/esp/v5.4/esp-idf/components/esp_hw_support/port/esp32s3/. -I/home/henry/esp/v5.4/esp-idf/components/esp_hw_support/port/esp32s3/include -I/home/henry/esp/v5.4/esp-idf/components/heap/include -I/home/henry/esp/v5.4/esp-idf/components/heap/tlsf -I/home/henry/esp/v5.4/esp-idf/components/log/include -I/home/henry/esp/v5.4/esp-idf/components/soc/include -I/home/henry/esp/v5.4/esp-idf/components/soc/esp32s3 -I/home/henry/esp/v5.4/esp-idf/components/soc/esp32s3/include -I/home/henry/esp/v5.4/esp-idf/components/soc/esp32s3/register -I/home/henry/esp/v5.4/esp-idf/components/hal/platform_port/include -I/home/henry/esp/v5.4/esp-idf/components/hal/esp32s3/include -I/home/henry/esp/v5.4/esp-idf/components/hal/include -I/home/henry/esp/v5.4/esp-idf/components/esp_rom/include -I/home/henry/esp/v5.4/esp-idf/components/esp_rom/esp32s3/include -I/home/henry/esp/v5.4/esp-idf/components/esp_rom/esp32s3/include/esp32s3 -I/home/henry/esp/v5.4/esp-idf/components/esp_rom/esp32s3 -I/home/henry/esp/v5.4/esp-idf/components/esp_common/include -I/home/henry/esp/v5.4/esp-idf/components/esp_system/include -I/home/henry/esp/v5.4/esp-idf/components/esp_system/port/soc -I/home/henry/esp/v5.4/esp-idf/components/esp_system/port/include/private -I/home/henry/esp/v5.4/esp-idf/components/xtensa/esp32s3/include -I/home/henry/esp/v5.4/esp-idf/components/xtensa/include -I/home/henry/esp/v5.4/esp-idf/components/xtensa/deprecated_include -I/home/henry/esp/v5.4/esp-idf/components/lwip/include -I/home/henry/esp/v5.4/esp-idf/components/lwip/include/apps -I/home/henry/esp/v5.4/esp-idf/components/lwip/include/apps/sntp -I/home/henry/esp/v5.4/esp-idf/components/lwip/lwip/src/include -I/home/henry/esp/v5.4/esp-idf/components/lwip/port/include -I/home/henry/esp/v5.4/esp-idf/components/lwip/port/freertos/include -I/home/henry/esp/v5.4/esp-idf/components/lwip/port/esp32xx/include -I/home/henry/esp/v5.4/esp-idf/components/lwip/port/esp32xx/include/arch -I/home/henry/esp/v5.4/esp-idf/components/lwip/port/esp32xx/include/sys -I/home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/managed_components/espressif__esp-serial-flasher/include -I/home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/managed_components/espressif__esp-serial-flasher/port -I/home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/managed_components/espressif__esp-zboss-lib/include -I/home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/managed_components/espressif__esp-zigbee-lib/include -I/home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/managed_components/espressif__esp-zigbee-lib/include/radio_spinel -I/home/henry/esp/v5.4/esp-idf/components/driver/deprecated -I/home/henry/esp/v5.4/esp-idf/components/driver/i2c/include -I/home/henry/esp/v5.4/esp-idf/components/driver/touch_sensor/include -I/home/henry/esp/v5.4/esp-idf/components/driver/twai/include -I/home/henry/esp/v5.4/esp-idf/components/driver/touch_sensor/esp32s3/include -I/home/henry/esp/v5.4/esp-idf/components/esp_pm/include -I/home/henry/esp/v5.4/esp-idf/components/esp_ringbuf/include -I/home/henry/esp/v5.4/esp-idf/components/esp_driver_gpio/include -I/home/henry/esp/v5.4/esp-idf/components/esp_driver_pcnt/include -I/home/henry/esp/v5.4/esp-idf/components/esp_driver_gptimer/include -I/home/henry/esp/v5.4/esp-idf/components/esp_driver_spi/include -I/home/henry/esp/v5.4/esp-idf/components/esp_driver_mcpwm/include -I/home/henry/esp/v5.4/esp-idf/components/esp_driver_ana_cmpr/include -I/home/henry/esp/v5.4/esp-idf/components/esp_driver_i2s/include -I/home/henry/esp/v5.4/esp-idf/components/esp_driver_sdmmc/include -I/home/henry/esp/v5.4/esp-idf/components/sdmmc/include -I/home/henry/esp/v5.4/esp-idf/components/esp_driver_sdspi/include -I/home/henry/esp/v5.4/esp-idf/components/esp_driver_sdio/include -I/home/henry/esp/v5.4/esp-idf/components/esp_driver_dac/include -I/home/henry/esp/v5.4/esp-idf/components/esp_driver_rmt/include -I/home/henry/esp/v5.4/esp-idf/components/esp_driver_tsens/include -I/home/henry/esp/v5.4/esp-idf/components/esp_driver_sdm/include -I/home/henry/esp/v5.4/esp-idf/components/esp_driver_i2c/include -I/home/henry/esp/v5.4/esp-idf/components/esp_driver_uart/include -I/home/henry/esp/v5.4/esp-idf/components/vfs/include -I/home/henry/esp/v5.4/esp-idf/components/esp_driver_ledc/include -I/home/henry/esp/v5.4/esp-idf/components/esp_driver_parlio/include -I/home/henry/esp/v5.4/esp-idf/components/esp_driver_usb_serial_jtag/include -I/home/henry/esp/v5.4/esp-idf/components/ieee802154/include -I/home/henry/esp/v5.4/esp-idf/components/openthread/include -I/home/henry/esp/v5.4/esp-idf/components/openthread/openthread/include -I/home/henry/esp/v5.4/esp-idf/components/esp_netif/include -I/home/henry/esp/v5.4/esp-idf/components/esp_event/include -I/home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/managed_components/espressif__esp_rcp_update/include -I/home/henry/esp/v5.4/esp-idf/components/nvs_flash/include -I/home/henry/esp/v5.4/esp-idf/components/esp_partition/include -I/home/henry/esp/v5.4/esp-idf/components/mbedtls/port/include -I/home/henry/esp/v5.4/esp-idf/components/mbedtls/mbedtls/include -I/home/henry/esp/v5.4/esp-idf/components/mbedtls/mbedtls/library -I/home/henry/esp/v5.4/esp-idf/components/mbedtls/esp_crt_bundle/include -I/home/henry/esp/v5.4/esp-idf/components/mbedtls/mbedtls/3rdparty/everest/include -I/home/henry/esp/v5.4/esp-idf/components/mbedtls/mbedtls/3rdparty/p256-m -I/home/henry/esp/v5.4/esp-idf/components/mbedtls/mbedtls/3rdparty/p256-m/p256-m -I/home/henry/esp/v5.4/esp-idf/components/esp_app_format/include -I/home/henry/esp/v5.4/esp-idf/components/esp_bootloader_format/include -I/home/henry/esp/v5.4/esp-idf/components/app_update/include -I/home/henry/esp/v5.4/esp-idf/components/bootloader_support/include -I/home/henry/esp/v5.4/esp-idf/components/bootloader_support/bootloader_flash/include -I/home/henry/esp/v5.4/esp-idf/components/efuse/include -I/home/henry/esp/v5.4/esp-idf/components/efuse/esp32s3/include -I/home/henry/esp/v5.4/esp-idf/components/esp_mm/include -I/home/henry/esp/v5.4/esp-idf/components/spi_flash/include -I/home/henry/esp/v5.4/esp-idf/components/esp_security/include -I/home/henry/esp/v5.4/esp-idf/components/pthread/include -I/home/henry/esp/v5.4/esp-idf/components/esp_timer/include -I/home/henry/esp/v5.4/esp-idf/components/app_trace/include -I/home/henry/esp/v5.4/esp-idf/components/esp_phy/include -I/home/henry/esp/v5.4/esp-idf/components/esp_phy/esp32s3/include -I/home/henry/esp/v5.4/esp-idf/components/esp_vfs_console/include -I/home/henry/esp/v5.4/esp-idf/components/wpa_supplicant/include -I/home/henry/esp/v5.4/esp-idf/components/wpa_supplicant/port/include -I/home/henry/esp/v5.4/esp-idf/components/wpa_supplicant/esp_supplicant/include -I/home/henry/esp/v5.4/esp-idf/components/esp_coex/include -I/home/henry/esp/v5.4/esp-idf/components/esp_wifi/include -I/home/henry/esp/v5.4/esp-idf/components/esp_wifi/include/local -I/home/henry/esp/v5.4/esp-idf/components/esp_wifi/wifi_apps/include -I/home/henry/esp/v5.4/esp-idf/components/esp_wifi/wifi_apps/nan_app/include -I/home/henry/esp/v5.4/esp-idf/components/bt/include/esp32c3/include -I/home/henry/esp/v5.4/esp-idf/components/bt/common/osi/include -I/home/henry/esp/v5.4/esp-idf/components/bt/common/api/include/api -I/home/henry/esp/v5.4/esp-idf/components/bt/common/btc/profile/esp/blufi/include -I/home/henry/esp/v5.4/esp-idf/components/bt/common/btc/profile/esp/include -I/home/henry/esp/v5.4/esp-idf/components/bt/common/hci_log/include -I/home/henry/esp/v5.4/esp-idf/components/bt/host/nimble/nimble/nimble/host/include -I/home/henry/esp/v5.4/esp-idf/components/bt/host/nimble/nimble/nimble/include -I/home/henry/esp/v5.4/esp-idf/components/bt/host/nimble/nimble/nimble/host/services/ans/include -I/home/henry/esp/v5.4/esp-idf/components/bt/host/nimble/nimble/nimble/host/services/bas/include -I/home/henry/esp/v5.4/esp-idf/components/bt/host/nimble/nimble/nimble/host/services/dis/include -I/home/henry/esp/v5.4/esp-idf/components/bt/host/nimble/nimble/nimble/host/services/gap/include -I/home/henry/esp/v5.4/esp-idf/components/bt/host/nimble/nimble/nimble/host/services/gatt/include -I/home/henry/esp/v5.4/esp-idf/components/bt/host/nimble/nimble/nimble/host/services/hr/include -I/home/henry/esp/v5.4/esp-idf/components/bt/host/nimble/nimble/nimble/host/services/htp/include -I/home/henry/esp/v5.4/esp-idf/components/bt/host/nimble/nimble/nimble/host/services/ias/include -I/home/henry/esp/v5.4/esp-idf/components/bt/host/nimble/nimble/nimble/host/services/ipss/include -I/home/henry/esp/v5.4/esp-idf/components/bt/host/nimble/nimble/nimble/host/services/lls/include -I/home/henry/esp/v5.4/esp-idf/components/bt/host/nimble/nimble/nimble/host/services/prox/include -I/home/henry/esp/v5.4/esp-idf/components/bt/host/nimble/nimble/nimble/host/services/cts/include -I/home/henry/esp/v5.4/esp-idf/components/bt/host/nimble/nimble/nimble/host/services/tps/include -I/home/henry/esp/v5.4/esp-idf/components/bt/host/nimble/nimble/nimble/host/services/hid/include -I/home/henry/esp/v5.4/esp-idf/components/bt/host/nimble/nimble/nimble/host/services/sps/include -I/home/henry/esp/v5.4/esp-idf/components/bt/host/nimble/nimble/nimble/host/services/cte/include -I/home/henry/esp/v5.4/esp-idf/components/bt/host/nimble/nimble/nimble/host/util/include -I/home/henry/esp/v5.4/esp-idf/components/bt/host/nimble/nimble/nimble/host/store/ram/include -I/home/henry/esp/v5.4/esp-idf/components/bt/host/nimble/nimble/nimble/host/store/config/include -I/home/henry/esp/v5.4/esp-idf/components/bt/host/nimble/nimble/porting/nimble/include -I/home/henry/esp/v5.4/esp-idf/components/bt/host/nimble/port/include -I/home/henry/esp/v5.4/esp-idf/components/bt/host/nimble/nimble/nimble/transport/include -I/home/henry/esp/v5.4/esp-idf/components/bt/porting/include -I/home/henry/esp/v5.4/esp-idf/components/bt/host/nimble/nimble/porting/npl/freertos/include -I/home/henry/esp/v5.4/esp-idf/components/bt/host/nimble/esp-hci/include -I/home/henry/esp/v5.4/esp-idf/components/unity/include -I/home/henry/esp/v5.4/esp-idf/components/unity/unity/src -I/home/henry/esp/v5.4/esp-idf/components/cmock/CMock/src -I/home/henry/esp/v5.4/esp-idf/components/console -I/home/henry/esp/v5.4/esp-idf/components/http_parser -I/home/henry/esp/v5.4/esp-idf/components/esp-tls -I/home/henry/esp/v5.4/esp-idf/components/esp-tls/esp-tls-crypto -I/home/henry/esp/v5.4/esp-idf/components/esp_adc/include -I/home/henry/esp/v5.4/esp-idf/components/esp_adc/interface -I/home/henry/esp/v5.4/esp-idf/components/esp_adc/esp32s3/include -I/home/henry/esp/v5.4/esp-idf/components/esp_adc/deprecated/include -I/home/henry/esp/v5.4/esp-idf/components/esp_driver_isp/include -I/home/henry/esp/v5.4/esp-idf/components/esp_driver_cam/include -I/home/henry/esp/v5.4/esp-idf/components/esp_driver_cam/interface -I/home/henry/esp/v5.4/esp-idf/components/esp_driver_jpeg/include -I/home/henry/esp/v5.4/esp-idf/components/esp_driver_ppa/include -I/home/henry/esp/v5.4/esp-idf/components/esp_eth/include -I/home/henry/esp/v5.4/esp-idf/components/esp_gdbstub/include -I/home/henry/esp/v5.4/esp-idf/components/esp_hid/include -I/home/henry/esp/v5.4/esp-idf/components/tcp_transport/include -I/home/henry/esp/v5.4/esp-idf/components/esp_http_client/include -I/home/henry/esp/v5.4/esp-idf/components/esp_http_server/include -I/home/henry/esp/v5.4/esp-idf/components/esp_https_ota/include -I/home/henry/esp/v5.4/esp-idf/components/esp_https_server/include -I/home/henry/esp/v5.4/esp-idf/components/esp_psram/include -I/home/henry/esp/v5.4/esp-idf/components/esp_lcd/include -I/home/henry/esp/v5.4/esp-idf/components/esp_lcd/interface -I/home/henry/esp/v5.4/esp-idf/components/esp_lcd/rgb/include -I/home/henry/esp/v5.4/esp-idf/components/protobuf-c/protobuf-c -I/home/henry/esp/v5.4/esp-idf/components/protocomm/include/common -I/home/henry/esp/v5.4/esp-idf/components/protocomm/include/security -I/home/henry/esp/v5.4/esp-idf/components/protocomm/include/transports -I/home/henry/esp/v5.4/esp-idf/components/protocomm/include/crypto/srp6a -I/home/henry/esp/v5.4/esp-idf/components/protocomm/proto-c -I/home/henry/esp/v5.4/esp-idf/components/esp_local_ctrl/include -I/home/henry/esp/v5.4/esp-idf/components/espcoredump/include -I/home/henry/esp/v5.4/esp-idf/components/espcoredump/include/port/xtensa -I/home/henry/esp/v5.4/esp-idf/components/wear_levelling/include -I/home/henry/esp/v5.4/esp-idf/components/fatfs/diskio -I/home/henry/esp/v5.4/esp-idf/components/fatfs/src -I/home/henry/esp/v5.4/esp-idf/components/fatfs/vfs -I/home/henry/esp/v5.4/esp-idf/components/idf_test/include -I/home/henry/esp/v5.4/esp-idf/components/idf_test/include/esp32s3 -I/home/henry/esp/v5.4/esp-idf/components/json/cJSON -I/home/henry/esp/v5.4/esp-idf/components/mqtt/esp-mqtt/include -I/home/henry/esp/v5.4/esp-idf/components/nvs_sec_provider/include -I/home/henry/esp/v5.4/esp-idf/components/perfmon/include -I/home/henry/esp/v5.4/esp-idf/components/rt/include -I/home/henry/esp/v5.4/esp-idf/components/spiffs/include -I/home/henry/esp/v5.4/esp-idf/components/touch_element/include -I/home/henry/esp/v5.4/esp-idf/components/usb/include -I/home/henry/esp/v5.4/esp-idf/components/wifi_provisioning/include -I/home/henry/esp/workspace/esp-rainmaker/components/esp-insights/components/esp_diag_data_store/src/rtc_store -I/home/henry/esp/workspace/esp-rainmaker/components/esp-insights/components/esp_diag_data_store/include -I/home/henry/esp/workspace/esp-rainmaker/components/rmaker_common/include -I/home/henry/esp/workspace/esp-rainmaker/components/esp-insights/components/esp_diagnostics/include -I/home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/managed_components/espressif__cbor/port/include -I/home/henry/esp/workspace/esp-rainmaker/components/esp-insights/components/esp_insights/include -I/home/henry/esp/workspace/esp-rainmaker/components/jsmn/include -I/home/henry/esp/workspace/esp-rainmaker/components/json_parser/include -I/home/henry/esp/workspace/esp-rainmaker/components/json_generator/include -I/home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/managed_components/espressif__mdns/include -I/home/henry/esp/workspace/esp-rainmaker/components/esp_schedule/include -I/home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/managed_components/espressif__network_provisioning/include -I/home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/managed_components/espressif__esp_secure_cert_mgr/include -I/home/henry/esp/workspace/esp-rainmaker/components/esp_rainmaker/include -I/home/henry/esp/workspace/esp-rainmaker/examples/common/app_insights -I/home/henry/esp/workspace/esp-rainmaker/examples/common/qrcode/include -I/home/henry/esp/workspace/esp-rainmaker/examples/common/app_network -I/home/henry/esp/workspace/esp-rainmaker/examples/common/gpio_button/button/include -I/home/henry/esp/workspace/esp-rainmaker/examples/common/app_reset -I/home/henry/esp/workspace/esp-rainmaker/examples/common/ledc_driver -I/home/henry/esp/workspace/esp-rainmaker/examples/common/ws2812_led -I/home/henry/esp/v5.4/esp-idf/examples/common_components/protocol_examples_common/include -mlongcalls  -fno-builtin-memcpy -fno-builtin-memset -fno-builtin-bzero -fno-builtin-stpcpy -fno-builtin-strncpy -fdiagnostics-color=always -ffunction-sections -fdata-sections -Wall -Werror=all -Wno-error=unused-function -Wno-error=unused-variable -Wno-error=unused-but-set-variable -Wno-error=deprecated-declarations -Wextra -Wno-error=extra -Wno-unused-parameter -Wno-sign-compare -Wno-enum-conversion -gdwarf-4 -ggdb -Os -freorder-blocks -fmacro-prefix-map=/home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway=. -fmacro-prefix-map=/home/henry/esp/v5.4/esp-idf=/IDF -fstrict-volatile-bitfields -fno-jump-tables -fno-tree-switch-conversion -std=gnu17 -Wno-old-style-declaration -Wno-strict-prototypes -MD -MT esp-idf/main/CMakeFiles/__idf_main.dir/esp_gateway_main.c.obj -MF esp-idf/main/CMakeFiles/__idf_main.dir/esp_gateway_main.c.obj.d -o esp-idf/main/CMakeFiles/__idf_main.dir/esp_gateway_main.c.obj -c /home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/main/esp_gateway_main.c
/home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/main/esp_gateway_main.c: In function 'esp_zb_app_signal_handler':
/home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/main/esp_gateway_main.c:127:5: error: unknown type name 'esp_zb_zdo_signal_macsplit_dev_boot_params_t'; did you mean 'esp_zb_zdo_signal_can_sleep_params_t'?
  127 |     esp_zb_zdo_signal_macsplit_dev_boot_params_t *rcp_version = NULL;
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |     esp_zb_zdo_signal_can_sleep_params_t
/home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/main/esp_gateway_main.c:136:10: error: 'ESP_ZB_MACSPLIT_DEVICE_BOOT' undeclared (first use in this function)
  136 |     case ESP_ZB_MACSPLIT_DEVICE_BOOT:
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/main/esp_gateway_main.c:136:10: note: each undeclared identifier is reported only once for each function it appears in
/home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/main/esp_gateway_main.c:138:24: error: 'esp_zb_zdo_signal_macsplit_dev_boot_params_t' undeclared (first use in this function); did you mean 'esp_zb_zdo_signal_can_sleep_params_t'?
  138 |         rcp_version = (esp_zb_zdo_signal_macsplit_dev_boot_params_t *)esp_zb_app_signal_get_params(p_sg_p);
      |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                        esp_zb_zdo_signal_can_sleep_params_t
/home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/main/esp_gateway_main.c:138:70: error: expected expression before ')' token
  138 |         rcp_version = (esp_zb_zdo_signal_macsplit_dev_boot_params_t *)esp_zb_app_signal_get_params(p_sg_p);
      |                                                                      ^
In file included from /home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/main/esp_gateway_main.c:10:
/home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/main/esp_gateway_main.c:139:60: error: request for member 'version_str' in something not a structure or union
  139 |         ESP_LOGI(TAG, "Running RCP Version:%s", rcp_version->version_str);
      |                                                            ^~
/home/henry/esp/v5.4/esp-idf/components/log/include/esp_log.h:182:137: note: in definition of macro 'ESP_LOG_LEVEL'
  182 |         if (level==ESP_LOG_ERROR )          { esp_log_write(ESP_LOG_ERROR,      tag, LOG_FORMAT(E, format), esp_log_timestamp(), tag, ##__VA_ARGS__); } \
      |                                                                                                                                         ^~~~~~~~~~~
/home/henry/esp/v5.4/esp-idf/components/log/include/esp_log.h:114:38: note: in expansion of macro 'ESP_LOG_LEVEL_LOCAL'
  114 | #define ESP_LOGI( tag, format, ... ) ESP_LOG_LEVEL_LOCAL(ESP_LOG_INFO,    tag, format, ##__VA_ARGS__)
      |                                      ^~~~~~~~~~~~~~~~~~~
/home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/main/esp_gateway_main.c:139:9: note: in expansion of macro 'ESP_LOGI'
  139 |         ESP_LOGI(TAG, "Running RCP Version:%s", rcp_version->version_str);
      |         ^~~~~~~~
/home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/main/esp_gateway_main.c:139:60: error: request for member 'version_str' in something not a structure or union
  139 |         ESP_LOGI(TAG, "Running RCP Version:%s", rcp_version->version_str);
      |                                                            ^~
/home/henry/esp/v5.4/esp-idf/components/log/include/esp_log.h:183:137: note: in definition of macro 'ESP_LOG_LEVEL'
  183 |         else if (level==ESP_LOG_WARN )      { esp_log_write(ESP_LOG_WARN,       tag, LOG_FORMAT(W, format), esp_log_timestamp(), tag, ##__VA_ARGS__); } \
      |                                                                                                                                         ^~~~~~~~~~~
/home/henry/esp/v5.4/esp-idf/components/log/include/esp_log.h:114:38: note: in expansion of macro 'ESP_LOG_LEVEL_LOCAL'
  114 | #define ESP_LOGI( tag, format, ... ) ESP_LOG_LEVEL_LOCAL(ESP_LOG_INFO,    tag, format, ##__VA_ARGS__)
      |                                      ^~~~~~~~~~~~~~~~~~~
/home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/main/esp_gateway_main.c:139:9: note: in expansion of macro 'ESP_LOGI'
  139 |         ESP_LOGI(TAG, "Running RCP Version:%s", rcp_version->version_str);
      |         ^~~~~~~~
/home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/main/esp_gateway_main.c:139:60: error: request for member 'version_str' in something not a structure or union
  139 |         ESP_LOGI(TAG, "Running RCP Version:%s", rcp_version->version_str);
      |                                                            ^~
/home/henry/esp/v5.4/esp-idf/components/log/include/esp_log.h:184:137: note: in definition of macro 'ESP_LOG_LEVEL'
  184 |         else if (level==ESP_LOG_DEBUG )     { esp_log_write(ESP_LOG_DEBUG,      tag, LOG_FORMAT(D, format), esp_log_timestamp(), tag, ##__VA_ARGS__); } \
      |                                                                                                                                         ^~~~~~~~~~~
/home/henry/esp/v5.4/esp-idf/components/log/include/esp_log.h:114:38: note: in expansion of macro 'ESP_LOG_LEVEL_LOCAL'
  114 | #define ESP_LOGI( tag, format, ... ) ESP_LOG_LEVEL_LOCAL(ESP_LOG_INFO,    tag, format, ##__VA_ARGS__)
      |                                      ^~~~~~~~~~~~~~~~~~~
/home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/main/esp_gateway_main.c:139:9: note: in expansion of macro 'ESP_LOGI'
  139 |         ESP_LOGI(TAG, "Running RCP Version:%s", rcp_version->version_str);
      |         ^~~~~~~~
/home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/main/esp_gateway_main.c:139:60: error: request for member 'version_str' in something not a structure or union
  139 |         ESP_LOGI(TAG, "Running RCP Version:%s", rcp_version->version_str);
      |                                                            ^~
/home/henry/esp/v5.4/esp-idf/components/log/include/esp_log.h:185:137: note: in definition of macro 'ESP_LOG_LEVEL'
  185 |         else if (level==ESP_LOG_VERBOSE )   { esp_log_write(ESP_LOG_VERBOSE,    tag, LOG_FORMAT(V, format), esp_log_timestamp(), tag, ##__VA_ARGS__); } \
      |                                                                                                                                         ^~~~~~~~~~~
/home/henry/esp/v5.4/esp-idf/components/log/include/esp_log.h:114:38: note: in expansion of macro 'ESP_LOG_LEVEL_LOCAL'
  114 | #define ESP_LOGI( tag, format, ... ) ESP_LOG_LEVEL_LOCAL(ESP_LOG_INFO,    tag, format, ##__VA_ARGS__)
      |                                      ^~~~~~~~~~~~~~~~~~~
/home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/main/esp_gateway_main.c:139:9: note: in expansion of macro 'ESP_LOGI'
  139 |         ESP_LOGI(TAG, "Running RCP Version:%s", rcp_version->version_str);
      |         ^~~~~~~~
/home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/main/esp_gateway_main.c:139:60: error: request for member 'version_str' in something not a structure or union
  139 |         ESP_LOGI(TAG, "Running RCP Version:%s", rcp_version->version_str);
      |                                                            ^~
/home/henry/esp/v5.4/esp-idf/components/log/include/esp_log.h:186:137: note: in definition of macro 'ESP_LOG_LEVEL'
  186 |         else                                { esp_log_write(ESP_LOG_INFO,       tag, LOG_FORMAT(I, format), esp_log_timestamp(), tag, ##__VA_ARGS__); } \
      |                                                                                                                                         ^~~~~~~~~~~
/home/henry/esp/v5.4/esp-idf/components/log/include/esp_log.h:114:38: note: in expansion of macro 'ESP_LOG_LEVEL_LOCAL'
  114 | #define ESP_LOGI( tag, format, ... ) ESP_LOG_LEVEL_LOCAL(ESP_LOG_INFO,    tag, format, ##__VA_ARGS__)
      |                                      ^~~~~~~~~~~~~~~~~~~
/home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/main/esp_gateway_main.c:139:9: note: in expansion of macro 'ESP_LOGI'
  139 |         ESP_LOGI(TAG, "Running RCP Version:%s", rcp_version->version_str);
      |         ^~~~~~~~
/home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/main/esp_gateway_main.c: In function 'esp_zb_task':
/home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/main/esp_gateway_main.c:241:5: warning: 'esp_zb_main_loop_iteration' is deprecated [-Wdeprecated-declarations]
  241 |     esp_zb_main_loop_iteration();
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/main/esp_app_rainmaker.h:12,
                 from /home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/main/esp_gateway_main.c:12:
/home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/managed_components/espressif__esp-zigbee-lib/include/esp_zigbee_core.h:691:6: note: declared here
  691 | void esp_zb_main_loop_iteration(void);
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~~
ninja: build stopped: subcommand failed.
ninja failed with exit code 1, output of the command is in the /home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/build/log/idf_py_stderr_output_209451 and /home/henry/esp/workspace/esp-rainmaker/examples/zigbee_gateway/build/log/idf_py_stdout_output_209451
```
<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

Fixes #347 (MEGH-6454)

## Testing

Commits were tested with esp32s3 development kit ESP Thread Border Router / Zigbee Gateway V1.2, latest esp-rainmaker, ESP-IDF 5.4

Rainmaker mobile app can successfully add this Zigbee Gateway in.




---

